### PR TITLE
Android Auto Wireless

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,9 @@ your device may fail to boot due to permission errors!
 4. Install [Android Auto](https://play.google.com/store/apps/details?id=com.google.android.projection.gearhead) through [Aurora Store](https://gitlab.com/AuroraOSS/AuroraStore),   
     use `Root installer` as installation method to "install as Google Play Store".   
     *(You can also install through your Package Manager if Aurora doesn't work, not preferred as it does not "install as Google Play Store")*
-5. Settings => Apps => See all apps => Android Auto => Mobile data & Wi-Fi => UnCheck all
-6. Settings => Notifications => Device & app notifications => Android Auto => Check `Allow notification access` => Ok *(**Settings will still be restricted!**)*
-7. Settings => Apps => See all apps => Android Auto => Triple dot icon => Allow restricted settings
-8. Settings => Notifications => Device & app notifications => Android Auto => Check `Allow notification access` => Allow
-9. Settings => Connected Devices => Connection Preferences => Android Auto
-    - System => UnCheck `Google Analytics`
+5. **(Optional)** Settings => Apps => See all apps => Android Auto => Mobile data & Wi-Fi => UnCheck all - ***WARNING:*** **THIS WILL MAKE IT IMPOSSIBLE TO CONNECT WIRELESSLY**. If you want to use Android Auto wirelessly you should keep those enabled and skip this step. This step provides further privacy,
+6. Settings => Notifications => Device & app notifications => Android Auto => Check `Allow notification access` => Allow
+8. Settings => Connected Devices => Connection Preferences => Android Auto
     - About => Tap `Version` a lot => Accept PopUp to become a developer
     - Triple dot icon *(top right corner)* => Developer Settings
         - Application Mode => Developer
@@ -67,10 +64,11 @@ To mitigate this, first un-install the app, then you can use following ways to "
 
 - **Play Store APKs**: Use [Aurora Store](https://gitlab.com/AuroraOSS/AuroraStore) + `Root installer` as the installation method, works for single + split APKs.
 - **Non Play Store APKs**: Use [King Installer](https://github.com/Rikj000/KingInstaller), works for single APK.
-- Or use **direct ADB install**, works for single APK:   
+- Or use **direct Android Shell install**, works for single APK:   
     ```bash
     pm install -i "com.android.vending" <apk>
     ```
+- **Split APKs**: Use [AppManager](https://github.com/MuntashirAkon/AppManager), in the settings in `Installer => Installer App` choose microG Companion or manually enter `com.android.vending` before installing the APK.
 
 #### Android Auto still won't show some apps.
 Some apps have additional restrictions applied on them by AA,   

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ your device may fail to boot due to permission errors!
 4. Install [Android Auto](https://play.google.com/store/apps/details?id=com.google.android.projection.gearhead) through [Aurora Store](https://gitlab.com/AuroraOSS/AuroraStore),   
     use `Root installer` as installation method to "install as Google Play Store".   
     *(You can also install through your Package Manager if Aurora doesn't work, not preferred as it does not "install as Google Play Store")*
-5. **(Optional)** Settings => Apps => See all apps => Android Auto => Mobile data & Wi-Fi => UnCheck all - ***WARNING:*** **THIS WILL MAKE IT IMPOSSIBLE TO CONNECT WIRELESSLY**. If you want to use Android Auto wirelessly you should keep those enabled and skip this step. This step provides further privacy,
-6. Settings => Notifications => Device & app notifications => Android Auto => Check `Allow notification access` => Allow
+5. **(Optional)** Settings => Apps => See all apps => Android Auto => Mobile data & Wi-Fi => UnCheck all - ***WARNING:*** **THIS WILL MAKE IT IMPOSSIBLE TO CONNECT WIRELESSLY**. If you want to use Android Auto wirelessly you should keep these options enabled (already enabled by default) and skip this step. This step only provides further privacy.
+6. Settings => Notifications => Device & app notifications => Android Auto => Check `Allow Notification Access` => Allow
 8. Settings => Connected Devices => Connection Preferences => Android Auto
     - About => Tap `Version` a lot => Accept PopUp to become a developer
     - Triple dot icon *(top right corner)* => Developer Settings


### PR DESCRIPTION
Things that caught my attention:
 - I thought wireless is not possible at all, see #13 . With my documentation changes it should be clear users have a choice if they want Android Auto wireless or not. I get the added privacy step of disabling traffic from and to Android Auto, but some users need the feature.
 - The Google Analytics disabling (see #21 ) is not a GUI thing anymore for a while now, can't remember since which version though. Removed step.
 - Allow restricted settings do not exist #18 , removed step (maybe for some specific OEM?).
 - Added new split APK install method, very user friendly and root is not even needed (optional).
 - PM install is technically an Android shell command, to prevent confusion I personally thought removing the word ADB does a slightly better job.

These issues can be closed since the documentation now answers these questions.